### PR TITLE
Update howto.html for working rpi-imager version

### DIFF
--- a/web/templates/howto.html
+++ b/web/templates/howto.html
@@ -113,7 +113,7 @@
                          src="https://github.com/dirkhh/adsb-feeder-image/assets/237471/7e0dd1f6-abf0-4b59-b6de-a14ecb86b541">
                 </div>
             </li>
-            <li class="mt-2">Use the <a href="https://www.raspberrypi.com/software">Raspberry Pi Imager</a> to write the
+            <li class="mt-2">Use the <a href="https://github.com/raspberrypi/rpi-imager/releases/tag/v1.8.5">Raspberry Pi Imager version 1.8.5</a> to write the
                 image you downloaded earlier to the SD card.
                 <div class="media mt-2">
                     <ol class="media-body">


### PR DESCRIPTION
rpi-imager version 2 doesn't allow customization of the ADSB.im-image anymore. Version 1.9.x is known to have several issues, making version 1.8.5 the last viable release.